### PR TITLE
Convert URL to String without omitting default port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use actix_web::{
 };
 use command::*;
 use state::*;
+use util::url_to_string;
 use std::sync::Arc;
 use structopt::StructOpt;
 use subxt::{ClientBuilder, DefaultConfig, PolkadotExtrinsicParams};
@@ -28,7 +29,7 @@ async fn main() -> std::io::Result<()> {
     let opt = Opt::from_args();
 
     let api = ClientBuilder::new()
-        .set_url(opt.node_server.to_string())
+        .set_url(url_to_string(opt.node_server))
         .build()
         .await
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use sp_core::Pair;
 use sugarfunge_api_types::primitives::*;
 use sugarfunge_api_types::sugarfunge;
+use url::Url;
 
 #[derive(Serialize, Deserialize, Debug, Display)]
 #[display(fmt = "{:?} {:?}", message, description)]
@@ -58,4 +59,15 @@ pub fn get_pair_from_seed(seed: &Seed) -> error::Result<sp_core::sr25519::Pair> 
         let req_error = serde_json::to_string_pretty(&req_error).unwrap();
         error::ErrorBadRequest(req_error)
     })
+}
+
+pub fn url_to_string(url: Url) -> String {
+    let mut res = url.to_string();
+    match (url.port(), url.port_or_known_default()) {
+        (None, Some(port)) => {
+            res.insert_str(res.len() - 1, &format!(":{}", port));
+            res
+        }
+        _ => res,
+    }
 }


### PR DESCRIPTION
A similar issue was happening on the `paritytech/cargo-contract` repository which was solved by the implementation done here.

https://github.com/paritytech/cargo-contract/issues/587
